### PR TITLE
Restructure Routes & Controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ I also see text that says "Logged in as Mike Dao" (or whatever my name is)
 ```
 
 ```
-[ ] done
+[X] done
 
 User Story 4, Merchant Navigation
 

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,9 @@
+class Admin::UsersController < Admin::BaseController
+  def index
+    # this is populated by default html in applications.html.erb
+  end
+
+  def show
+    @user = User.find(session[:user_id])
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,16 +11,12 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
-  def current_regular?
-    current_user && current_user.regular?
+  def current_admin?
+    current_user && current_user.admin?
   end
 
   # def current_merchant?
   #   current_user && current_user.merchant?
-  # end
-  #
-  # def current_admin?
-  #   current_user && current_user.admin?
   # end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :cart, :current_user
+  helper_method :cart, :current_user, :current_admin?, :current_merchant?
 
   def cart
     @cart ||= Cart.new(session[:cart] ||= Hash.new(0))
@@ -15,8 +15,7 @@ class ApplicationController < ActionController::Base
     current_user && current_user.admin?
   end
 
-  # def current_merchant?
-  #   current_user && current_user.merchant?
-  # end
-
+  def current_merchant?
+    current_user && current_user.merchant?
+  end
 end

--- a/app/controllers/regular/base_controller.rb
+++ b/app/controllers/regular/base_controller.rb
@@ -1,8 +1,0 @@
-class Regular::BaseController < ApplicationController
-  before_action :require_regular
-
-  def require_regular
-    puts "Running require_regular"
-    render file: "/public/404" unless current_regular?
-  end
-end

--- a/app/controllers/regular/dashboard_controller.rb
+++ b/app/controllers/regular/dashboard_controller.rb
@@ -1,5 +1,0 @@
-class Regular::DashboardController < Regular::BaseController
-  def index
-    # this is populated by default html in applications.html.erb
-  end
-end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,11 @@
 class UsersController <ApplicationController
 
   def new
+    # displays registration form
   end
 
   def show
-    if current_user
-      @user = User.find(session[:user_id])
-    else
-      render file: "/public/404"
-    end 
+    render file: "/public/404" unless current_user
   end
 
   def create
@@ -18,7 +15,7 @@ class UsersController <ApplicationController
       session[:user_id] = new_user.id
       redirect_to "/profile"
     else
-      flash[:errors] = new_user.errors.full_messages.to_sentence
+      flash[:errors] = new_user.errors.full_messages
       redirect_to "/register"
     end
   end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @user.name %></h1>
+<!-- not being used yet, just placeholder -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,14 @@
       <%= link_to "All Merchants", "/merchants"%>
       <%= link_to "All Items", "/items"%>
       <%= link_to "Cart: #{cart.total_items}", "/cart" %>
-      <% if current_user %>
+      <% if current_admin? %>
+        <%= link_to "Logout", "/logout" %>
+        <%= link_to "Profile", "/profile" %>
+      <% elsif current_merchant? %>
+        <%= link_to "Logout", "/logout" %>
+        <%= link_to "Profile", "/profile" %>
+        <%= link_to "Dashboard", "/merchant" %>
+      <% elsif current_user %>
         <%= link_to "Logout", "/logout" %>
         <%= link_to "Profile", "/profile" %>
         <p>Logged in as <%= current_user.name %></p>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <h1>Register a New User</h1>
-  <%= form_tag '/register', method: :post do %>
+  <%= form_tag '/users', method: :post do %>
     <%= label_tag :name%>
     <%= text_field_tag :name %>
     <%= label_tag :address%>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,1 @@
-<h1><%= @user.name %></h1>
+<h1><%= current_user.name %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,14 +37,17 @@ Rails.application.routes.draw do
   post "/orders", to: "orders#create"
   get "/orders/:id", to: "orders#show"
 
+  # REGISTER A NEW USER
   get "/register", to: "users#new"
-  post "/register", to: "users#create"
+  post "/users", to: "users#create"
   get "/profile", to: "users#show"
 
+  # LOGIN / LOGOUT SESSIONS
   get "/login", to: "sessions#new"
+  delete "/logout", to: "sessions#destroy"
 
-  namespace :regular do
-    get "/", to: "dashboard#index"
-    delete "/logout", to: "sessions#destroy"
+  namespace :admin do
+    get "/", to: "users#index"
+    # get "/users/:id", to: "users#show"
   end
 end

--- a/spec/features/users/merchant_nav_spec.rb
+++ b/spec/features/users/merchant_nav_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'As a merchant employee' do
+  describe 'I see the same links as a regular user' do
+
+    before :each do
+      @merchant = User.create!(name: "Merchant Dude",
+                                    address: "123 ABC St.",
+                                    city: "Denver",
+                                    state: "Colorado",
+                                    zip: "80202",
+                                    email: "merchant@hotmail.com",
+                                    password: "qwer",
+                                    role: 1)
+    end
+
+    xit 'Plus the following link to my merchant dashboard \"/merchant\"' do
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+      visit '/'
+
+      within 'nav' do
+        expect(page).to have_content('Home')
+        expect(page).to have_content('All Items')
+        expect(page).to have_content('All Merchants')
+        expect(page).to have_content('Cart: 0')
+
+        expect(page).to_not have_content('Login')
+        expect(page).to_not have_content('Register')
+
+        # expect(page).to have_content('Profile')
+        expect(page).to have_content('Logout')
+        # expect(page).to have_content('Merchant Dashboard')
+
+      end
+    end
+  end
+end

--- a/spec/features/users/merchant_nav_spec.rb
+++ b/spec/features/users/merchant_nav_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'As a merchant employee' do
                                     role: 1)
     end
 
-    xit 'Plus the following link to my merchant dashboard \"/merchant\"' do
+    it 'Plus the following link to my merchant dashboard \"/merchant\"' do
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
       visit '/'
@@ -26,9 +26,9 @@ RSpec.describe 'As a merchant employee' do
         expect(page).to_not have_content('Login')
         expect(page).to_not have_content('Register')
 
-        # expect(page).to have_content('Profile')
+        expect(page).to have_content('Profile')
         expect(page).to have_content('Logout')
-        # expect(page).to have_content('Merchant Dashboard')
+        expect(page).to have_content('Dashboard')
 
       end
     end

--- a/spec/features/users/user_nav_spec.rb
+++ b/spec/features/users/user_nav_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'As a default user' do
+  describe 'I see the same links as a visitor' do
+
+    before :each do
+      @existing_user = User.create!(name: "Bob Vance",
+                                    address: "123 ABC St.",
+                                    city: "Denver",
+                                    state: "Colorado",
+                                    zip: "80202",
+                                    email: "example@hotmail.com",
+                                    password: "qwer",
+                                    role: 0)
+    end
+
+    it 'Plus the following links: /profile, /logout' do
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@existing_user)
+      visit '/'
+
+      within 'nav' do
+        expect(page).to have_content('Home')
+        expect(page).to have_content('All Items')
+        expect(page).to have_content('All Merchants')
+        expect(page).to have_content('Cart: 0')
+
+        expect(page).to_not have_content('Login')
+        expect(page).to_not have_content('Register')
+
+        expect(page).to have_content('Profile')
+        expect(page).to have_content('Logout')
+        
+        expect(page).to have_content('Logged in as Bob Vance')
+      end
+    end
+  end
+end


### PR DESCRIPTION
So, instead of having separate namespaces for `regular`, `admin`, and `merchant` `Users`, we have an `admin` namespace that has access to all the same things a "regular user" would have. 

There are two different `UsersController`, one in the main Controllers folder, and one under the `Admin` namespace. 
The one outside handles new user registration, and will only show the `/profile -> #show` page if there is a current user present. That current user will always have access to this page (bc the user stories say the only thing that can't have profile access is a `visitor`.

@IamNorma @Ashkanthegreat @Jonathan-M-Wilson 
PS. ignore the branch name, it's 'merchant' because we're working on adding the merchant functionality next.