### PR TITLE
Disabled merchant items

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ Then I see everything that merchant would see
 All users can see a merchant index page which will list some basic information about each merchant. When admins visit this page, however, more functionality is found, and it is found at the "/admin/merchants" route.
 
 ```
-[ ] done
+[X] done
 
 User Story 38, Admin disables a merchant account
 
@@ -700,7 +700,7 @@ And I see a flash message that the merchant's account is now disabled
 ```
 
 ```
-[ ] done
+[X] done
 
 User Story 39, Disabled Merchant Item's are inactive
 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -7,9 +7,11 @@ class Admin::MerchantsController < ApplicationController
     merchant = Merchant.find(params[:id])
     if merchant.enabled == true
       merchant.update(enabled: false)
+      merchant.disable_items
       flash[:notice] = "This merchant\'s account is now disabled."
     else
-      merchant.update(enabled: true) #<---- this may be wrong?
+      merchant.update(enabled: true)
+      merchant.enable_items
       flash[:notice] = "This merchant\'s account is now enabled."
     end
     redirect_to "/merchants"

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -6,12 +6,10 @@ class Admin::MerchantsController < ApplicationController
   def update
     merchant = Merchant.find(params[:id])
     if merchant.enabled == true
-      merchant.update(enabled: false)
-      merchant.disable_items
+      merchant.disable
       flash[:notice] = "This merchant\'s account is now disabled."
     else
-      merchant.update(enabled: true)
-      merchant.enable_items
+      merchant.enable
       flash[:notice] = "This merchant\'s account is now enabled."
     end
     redirect_to "/merchants"

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -29,4 +29,17 @@ class Merchant <ApplicationRecord
   def pending_orders
     orders.where(status: "pending").distinct
   end
+
+  def disable_items
+    self.items.each do |item|
+      item.update(active?: false)
+    end
+  end
+
+  def enable_items
+    self.items.each do |item|
+      item.update(active?: true)
+    end
+  end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -30,13 +30,15 @@ class Merchant <ApplicationRecord
     orders.where(status: "pending").distinct
   end
 
-  def disable_items
+  def disable
+    self.update(enabled: false)
     self.items.each do |item|
       item.update(active?: false)
     end
   end
 
-  def enable_items
+  def enable
+    self.update(enabled: true)
     self.items.each do |item|
       item.update(active?: true)
     end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -55,13 +55,11 @@ RSpec.describe 'Admin merchant index page' do
 
           visit "/merchants"
 
-          within "#merchant-#{@meg.id}" do
+          within "#merchant-#{@brian.id}" do
             click_button('Disable')
           end
 
-          expect(@tire.active?).to eq(false)
-          expect(@bike_horn.active?).to eq(false)
-          expect(@bike_lock.active?).to eq(false)
+          expect(@brian.items.all?(:active?)).to eq(false)
         end
       end
     end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -53,9 +53,11 @@ RSpec.describe 'Admin merchant index page' do
       describe 'When I visit the merchant index page' do
         it 'And I click on the "disable" button for an enabled merchant; Then all of that merchant\'s items should be deactivated' do
 
-          visit "/admin/merchants"
+          visit "/merchants"
 
-          click_on "Disable"
+          within "#merchant-#{@meg.id}" do
+            click_button('Disable')
+          end
 
           expect(@tire.active?).to eq(false)
           expect(@bike_horn.active?).to eq(false)

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe 'As an admin' do
+
+  before :each do
+    @bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+    @admin = User.create!(name: "Admin", address: "789 Jkl St.", city: "Denver", state: "FL", zip: "80202", email: "admin@hotmail.com", password: "qwer", role: 2)
+
+    @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+
+    @bike_horn = @bike_shop.items.create(name: "Honk Honk", description: "Everyone will hear you comming", price: 20, image: "https://pbs.twimg.com/media/DkbR-8yVsAABrCg.png", inventory: 4)
+
+    @bike_lock = @bike_shop.items.create(name: "Krytonite Lock", description: "Keep your lock safe while you're away.", price: 60, image: "https://i5.walmartimages.com/asr/875f4ecf-877b-41ad-8754-eb67e54e0fdd_1.c38843c2225b1b0ed22a6d5fe3fed788.jpeg", inventory: 4)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end
+
+  describe 'When I visit the merchant index page' do
+    it 'And I click on the "disable" button for an enabled merchant; Then all of that merchant\'s items should be deactivated' do
+      
+      visit "/admin/merchants"
+
+      click_on "Disable"
+
+      expect(@tire.active?).to eq(false)
+      expect(@bike_horn.active?).to eq(false)
+      expect(@bike_lock.active?).to eq(false)
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -89,5 +89,13 @@ describe Merchant, type: :model do
 
       expect(jack.pending_orders).to eq([order_9])
     end
+
+    it '#disable_items' do
+
+      @meg.update(enabled: false)
+      @meg.disable_items
+      
+      expect(@tire.active?).to eq(false)
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -90,20 +90,18 @@ describe Merchant, type: :model do
       expect(jack.pending_orders).to eq([order_9])
     end
 
-    it '#disable_items' do
+    it '#disable & #enable' do
 
-      @meg.update(enabled: false)
-      @meg.disable_items
+      expect(@meg.enabled).to eq(true)
 
-      expect(@tire.active?).to eq(false)
-    end
+      @meg.disable
 
-    it '#enable_items' do
-
-      @meg.update(enabled: false)
       expect(@meg.enabled).to eq(false)
-      
-      @meg.enable_items
+      expect(@tire.active?).to eq(false)
+
+      @meg.enable
+
+      expect(@meg.enabled).to eq(true)
       expect(@tire.active?).to eq(true)
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -94,8 +94,17 @@ describe Merchant, type: :model do
 
       @meg.update(enabled: false)
       @meg.disable_items
-      
+
       expect(@tire.active?).to eq(false)
+    end
+
+    it '#enable_items' do
+
+      @meg.update(enabled: false)
+      expect(@meg.enabled).to eq(false)
+      
+      @meg.enable_items
+      expect(@tire.active?).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Since disabling a merchant's items happens at the same time as a merchant's enabled attribute is changed, I figured we could combine those into two model methods. `merchant#disable` sets `enabled == false` and that merchant's items to `active? == false` . The opposite is also true, with `merchant#enable`

US39 complete, all tests pass (including Jonathan's from 38)
Model specs also done.

@Jonathan-M-Wilson @IamNorma @Ashkanthegreat 